### PR TITLE
TASK: create + edit status

### DIFF
--- a/lib/commons/common_text_field.dart
+++ b/lib/commons/common_text_field.dart
@@ -9,8 +9,9 @@ import 'common_icon_button.dart';
 class CommonTextField extends StatefulWidget {
   final Function onTap;
   final dynamic editTarget;
+  final bool allowImages;
 
-  CommonTextField({@required this.onTap, this.editTarget});
+  CommonTextField({@required this.onTap, this.editTarget, this.allowImages = true});
 
   @override
   State<StatefulWidget> createState() => _CommonTextFieldState();
@@ -106,14 +107,18 @@ class _CommonTextFieldState extends State<CommonTextField> {
                 ),
                 Row(
                   children: [
-                    if (!isEdit) CommonIconButton(
-                      icon: Icons.add_a_photo,
-                      // 추후 갤러리에서만 아니라 카메라 촬영을 통해서 사진을 넣는 경우도 있어
-                      // make_profile_image.dart 참고하시면 좋을 듯합니다!
-                      onPressed: () async => await pickImage(type: 'gallery')
-                          .then((img) => setImageFile(img)),
+                    if (!isEdit && widget.allowImages) Row(
+                      children: [
+                        CommonIconButton(
+                          icon: Icons.add_a_photo,
+                          // 추후 갤러리에서만 아니라 카메라 촬영을 통해서 사진을 넣는 경우도 있어
+                          // make_profile_image.dart 참고하시면 좋을 듯합니다!
+                          onPressed: () async => await pickImage(type: 'gallery')
+                              .then((img) => setImageFile(img)),
+                        ),
+                        Padding(padding: EdgeInsets.only(right: 10))
+                      ],
                     ),
-                    if (!isEdit) Padding(padding: EdgeInsets.only(right: 10)),
                     CommonIconButton(
                       icon: Icons.send_outlined,
                       onPressed: () async {

--- a/lib/models/boards/task_msg.dart
+++ b/lib/models/boards/task_msg.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
+class TaskMsg extends ChangeNotifier {
+  final int id;
+  final String msg;
+  final String status; // { ONGOING, DONE }
+  final int taskId;
+
+  TaskMsg({this.id, this.msg, this.status, this.taskId});
+
+  factory TaskMsg.fromJson(Map<String, dynamic> json) {
+    return TaskMsg(
+      id: json["id"],
+      msg: json["msg"],
+      status: json["status"],
+      taskId: json["taskId"],
+    );
+  }
+}

--- a/lib/models/boards/user_task.dart
+++ b/lib/models/boards/user_task.dart
@@ -1,28 +1,33 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/foundation.dart';
 import '../profile.dart';
+import 'task_msg.dart';
 
 class UserTask extends ChangeNotifier {
   final int id;
   final int projectId;
   final Profile user;
-  final String task;
+  final List<TaskMsg> taskMessages;
   final String state;
 
   UserTask({
     this.id,
     this.projectId,
     this.user,
-    this.task,
+    this.taskMessages,
     this.state,
   });
 
   factory UserTask.fromJson(Map<String, dynamic> json) {
+    List<TaskMsg> taskMessages;
+
+    if (json["taskMsg"] != null) taskMessages = [...json["taskMsg"].map((msg) => TaskMsg.fromJson(msg))];
+
     return UserTask(
       id: json["id"],
       projectId: json["projectId"],
       user: Profile.fromJson(json["user"]),
-      task: json["taskMsg"],
+      taskMessages: taskMessages,
       state: json["userState"],
     );
   }

--- a/lib/models/boards/user_task.dart
+++ b/lib/models/boards/user_task.dart
@@ -20,13 +20,15 @@ class UserTask extends ChangeNotifier {
 
   factory UserTask.fromJson(Map<String, dynamic> json) {
     List<TaskMsg> taskMessages;
+    Profile user;
 
-    if (json["taskMsg"] != null) taskMessages = [...json["taskMsg"].map((msg) => TaskMsg.fromJson(msg))];
+    if (json["user"] != null) user = Profile.fromJson(json["user"]);
+    if (json["taskMessages"] != null) taskMessages = [...json["taskMessages"].map((msg) => TaskMsg.fromJson(msg))];
 
     return UserTask(
       id: json["id"],
       projectId: json["projectId"],
-      user: Profile.fromJson(json["user"]),
+      user: user,
       taskMessages: taskMessages,
       state: json["userState"],
     );

--- a/lib/models/project.dart
+++ b/lib/models/project.dart
@@ -26,7 +26,7 @@ class Project extends ChangeNotifier {
 
   /* parameters needed for boards tab */
   Thread notice;
-  final List<UserTask> tasks;
+  List<UserTask> tasks;
   List<Thread> threads;
   final Map<int, String> userStates; // { LEADER, MEMBER, GUEST, DECLINED, QUIT }
 
@@ -51,7 +51,8 @@ class Project extends ChangeNotifier {
     this.userStates,
   });
 
-  set(List<Thread> _threads) => threads = _threads;
+  set _tasks(List<UserTask> _tasks) => tasks = _tasks;
+  set _threads(List<Thread> _threads) => threads = _threads;
 
   factory Project.fromJson(Map<String, dynamic> json) {
     Thumbnail thumbnail;

--- a/lib/providers/boards/boards.dart
+++ b/lib/providers/boards/boards.dart
@@ -165,7 +165,7 @@ class Boards with ChangeNotifier {
 
     try {
       String authToken = await _authProvider.getFirebaseIdToken();
-      
+
       await HttpRequest()
         .put(
           path: "taskMsg/$taskMsgId",
@@ -457,8 +457,9 @@ class Boards with ChangeNotifier {
       print(e);
     } finally {
       if (res) {
-        fetchBoard(currentBoard.id);
-        fetchThreads(currentBoard.id);
+        await setTasks();
+        await fetchThreads(currentBoard.id);
+        notifyListeners();
       }
     }
   }

--- a/lib/providers/boards/boards.dart
+++ b/lib/providers/boards/boards.dart
@@ -131,6 +131,35 @@ class Boards with ChangeNotifier {
     return userTask;
   }
 
+  Future createTaskMsg({int taskId, Map<String, String> body}) async {
+    bool res = false;
+
+    try {
+      String authToken = await _authProvider.getFirebaseIdToken();
+
+      await HttpRequest()
+        .post(
+          path: "task/$taskId",
+          authToken: authToken,
+          body: body,
+      ).then((response) async {
+        if (response.statusCode == 200) {
+          res = true;
+          print("작업현황이 생성되었습니다.");
+          await setTasks();
+        } else {
+          throw new Exception("작업현황이 생성되지 않았습니다.");
+        }
+      });
+
+      return res;
+    } catch (e) {
+      print(e);
+    } finally {
+      notifyListeners();
+    }
+  }
+
   Future fetchThreads(int projectId) async {
     try {
       loading = true;

--- a/lib/providers/boards/boards.dart
+++ b/lib/providers/boards/boards.dart
@@ -160,6 +160,35 @@ class Boards with ChangeNotifier {
     }
   }
 
+  Future updateTaskMsg({int taskMsgId, Map<String, String> body}) async {
+    bool res = false;
+
+    try {
+      String authToken = await _authProvider.getFirebaseIdToken();
+      
+      await HttpRequest()
+        .put(
+          path: "taskMsg/$taskMsgId",
+          authToken: authToken,
+          body: body,
+      ).then((response) async {
+        if (response.statusCode == 200) {
+          res = true;
+          print("작업현황이 수정되었습니다.");
+          await setTasks();
+        } else {
+          throw new Exception("작업현황이 수정되지 않았습니다.");
+        }
+      });
+
+      return res;
+    } catch (e) {
+      print(e);
+    } finally {
+      notifyListeners();
+    }
+  }
+
   Future fetchThreads(int projectId) async {
     try {
       loading = true;

--- a/lib/providers/boards/boards.dart
+++ b/lib/providers/boards/boards.dart
@@ -447,7 +447,7 @@ class Boards with ChangeNotifier {
           queryParams: { "accept": "$accept" }
       ).then((response) {
         if (response.statusCode == 200) {
-          print("${accept ? "승인" : "반려"}가 완료되었습니다.");
+          print("${accept ? "승인이" : "반려가"} 완료되었습니다.");
           res = true;
         } else {
           throw new Exception("오직 프로젝트 리더만 승인/반려가 가능합니다.");
@@ -457,9 +457,7 @@ class Boards with ChangeNotifier {
       print(e);
     } finally {
       if (res) {
-        await setTasks();
-        await fetchThreads(currentBoard.id);
-        notifyListeners();
+        await fetchBoard(currentBoard.id);
       }
     }
   }

--- a/lib/screens/boards/board.dart
+++ b/lib/screens/boards/board.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 import '../../models/project.dart';
-import 'notice.dart';
-import 'tasks.dart';
-import 'threads.dart';
+import 'notice/notice.dart';
+import 'tasks/tasks.dart';
+import 'threads/threads.dart';
 import 'package:provider/provider.dart';
 import '../../providers/boards/boards.dart';
 import 'board_title/board_title.dart';

--- a/lib/screens/boards/board.dart
+++ b/lib/screens/boards/board.dart
@@ -22,6 +22,11 @@ class Board extends StatelessWidget {
       boardsProvider.fetchBoard(board.id);
     }
 
+    // temp
+    if (boardsProvider.currentBoard.tasks != null) {
+      print(boardsProvider.currentBoard.tasks.first.taskMessages);
+    }
+
     return !boardsProvider.loading
         ? SingleChildScrollView(
             child: Container(
@@ -32,7 +37,7 @@ class Board extends StatelessWidget {
                     padding: EdgeInsets.all(10),
                     child: Column(
                       children: [
-                        Notice(board.notice), 
+                        Notice(board.notice),
                         Tasks(board.tasks),
                         Threads(board.threads),
                       ],

--- a/lib/screens/boards/board.dart
+++ b/lib/screens/boards/board.dart
@@ -22,11 +22,6 @@ class Board extends StatelessWidget {
       boardsProvider.fetchBoard(board.id);
     }
 
-    // temp
-    if (boardsProvider.currentBoard.tasks != null) {
-      print(boardsProvider.currentBoard.tasks.first.taskMessages);
-    }
-
     return !boardsProvider.loading
         ? SingleChildScrollView(
             child: Container(

--- a/lib/screens/boards/notice/notice.dart
+++ b/lib/screens/boards/notice/notice.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
-import '../../commons/circular_border_container.dart';
-import '../../models/boards/thread.dart' as ThreadModel;
-import '../../commons/profile_thumbnail.dart';
+import '../../../commons/circular_border_container.dart';
+import '../../../models/boards/thread.dart' as ThreadModel;
+import '../../../commons/profile_thumbnail.dart';
 import 'package:provider/provider.dart';
-import '../../providers/boards/boards.dart';
+import '../../../providers/boards/boards.dart';
 
 class Notice extends StatelessWidget {
   final ThreadModel.Thread notice;

--- a/lib/screens/boards/task.dart
+++ b/lib/screens/boards/task.dart
@@ -43,10 +43,10 @@ class _TaskState extends State<Task> {
                     value: done,
                     onChanged: (val) => toggleDone(val)
                 ),
-                Text(
-                  widget.task.task,
-                  style: TextStyle(fontSize: 14),
-                ),
+                // Text(
+                //   widget.task.task,
+                //   style: TextStyle(fontSize: 14),
+                // ),
               ],
             ),
           )

--- a/lib/screens/boards/tasks.dart
+++ b/lib/screens/boards/tasks.dart
@@ -117,7 +117,7 @@ class TasksState extends State<Tasks> {
                 padding: EdgeInsets.all(10),
                 child: Column(
                   children: [
-                    if (selectedUserTask.task != null) Task(task: selectedUserTask),
+                    //if (selectedUserTask.task != null) Task(task: selectedUserTask),
                     Padding(
                       padding: EdgeInsets.only(top: 10),
                       child: Row(

--- a/lib/screens/boards/tasks/empty_task_message.dart
+++ b/lib/screens/boards/tasks/empty_task_message.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+import '../../../commons/common_text_field.dart';
+
+class EmptyTaskMessage extends StatelessWidget {
+
+  EmptyTaskMessage();
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: EdgeInsets.only(bottom: 10),
+      width: double.infinity,
+      child: DecoratedBox(
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(5),
+            color: Colors.white,
+          ),
+          child: Padding(
+            padding: EdgeInsets.only(right: 10),
+            child: CommonTextField(
+              onTap: null,
+              allowImages: false,
+            ),
+          )
+      ),
+    );
+  }
+}

--- a/lib/screens/boards/tasks/empty_task_message.dart
+++ b/lib/screens/boards/tasks/empty_task_message.dart
@@ -2,8 +2,9 @@ import 'package:flutter/material.dart';
 import '../../../commons/common_text_field.dart';
 
 class EmptyTaskMessage extends StatelessWidget {
+  final Function createTaskMsg;
 
-  EmptyTaskMessage();
+  EmptyTaskMessage({@required this.createTaskMsg});
 
   @override
   Widget build(BuildContext context) {
@@ -18,7 +19,7 @@ class EmptyTaskMessage extends StatelessWidget {
           child: Padding(
             padding: EdgeInsets.only(right: 10),
             child: CommonTextField(
-              onTap: null,
+              onTap: createTaskMsg,
               allowImages: false,
             ),
           )

--- a/lib/screens/boards/tasks/task.dart
+++ b/lib/screens/boards/tasks/task.dart
@@ -16,25 +16,63 @@ class _TaskState extends State<Task> {
 
   @override
   void initState() {
-    showAllMsgs = false; // After server code, init done to task.done
+    showAllMsgs = false;
     super.initState();
   }
 
-  void toggleShowAllMsgs(bool val) {
+  void toggleShowAllMsgs() {
     setState(() {
-      showAllMsgs = val;
+      showAllMsgs = !showAllMsgs;
     });
   }
+
+  Widget taskDropdownButton() => InkWell(
+    child: taskActionButton(showAllMsgs ? Icons.expand_less : Icons.expand_more),
+    onTap: toggleShowAllMsgs,
+  );
+
   @override
   Widget build(BuildContext context) {
     return Column(
       children: [
-        // adding new
-        // list first
-        TaskMessage(taskMsg: widget.task.taskMessages.first),
-        //if (showAllMsgs) widget.task.taskMessages[1:].map()
-        // others
+        if (widget.task.taskMessages != null) Column(
+          children: [
+            // adding new
+            // list first
+            if (widget.task.taskMessages.isNotEmpty) TaskMessage(taskMsg: widget.task.taskMessages.first),
+            if (showAllMsgs && widget.task.taskMessages.length > 1) Column(
+              children: widget.task.taskMessages
+                  .sublist(1)
+                  .map((e) => TaskMessage(taskMsg: e))
+                  .toList(),
+            ),
+            // others
+          ],
+        ),
+        Row(
+          mainAxisAlignment: MainAxisAlignment.end,
+          children: [
+            taskDropdownButton(),
+            Padding(padding: EdgeInsets.only(right: 10)),
+            taskAddButton(),
+          ],
+        )
       ],
     );
   }
 }
+
+Widget taskActionButton(IconData icon) => Container(
+    width: 30,
+    height: 30,
+    decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(30),
+        color: Colors.white
+    ),
+    child: Icon(icon)
+);
+
+Widget taskAddButton() => InkWell(
+  child: taskActionButton(Icons.add),
+  onTap: () {},
+);

--- a/lib/screens/boards/tasks/task.dart
+++ b/lib/screens/boards/tasks/task.dart
@@ -63,11 +63,14 @@ class _TaskState extends State<Task> {
         if (widget.task.taskMessages != null) Column(
           children: [
             if (addingNewMsg && isMyTask) EmptyTaskMessage(createTaskMsg: createTaskMsg),
-            if (widget.task.taskMessages.isNotEmpty) TaskMessage(taskMsg: widget.task.taskMessages.first),
+            if (widget.task.taskMessages.isNotEmpty) TaskMessage(
+              taskMsg: widget.task.taskMessages.first,
+              isMyTaskMsg: isMyTask
+            ),
             if (showAllMsgs && widget.task.taskMessages.length > 1) Column(
               children: widget.task.taskMessages
                   .sublist(1)
-                  .map((e) => TaskMessage(taskMsg: e))
+                  .map((e) => TaskMessage(taskMsg: e, isMyTaskMsg: isMyTask))
                   .toList(),
             ),
           ],

--- a/lib/screens/boards/tasks/task.dart
+++ b/lib/screens/boards/tasks/task.dart
@@ -1,6 +1,9 @@
 import 'package:flutter/material.dart';
 import '../../../models/boards/user_task.dart';
 import 'task_message.dart';
+import 'package:provider/provider.dart';
+import '../../../providers/boards/boards.dart';
+import 'empty_task_message.dart';
 
 class Task extends StatefulWidget {
   final UserTask task;
@@ -12,19 +15,24 @@ class Task extends StatefulWidget {
 }
 
 class _TaskState extends State<Task> {
+  bool addingNewMsg;
   bool showAllMsgs;
 
   @override
   void initState() {
+    addingNewMsg = false;
     showAllMsgs = false;
     super.initState();
   }
 
-  void toggleShowAllMsgs() {
-    setState(() {
-      showAllMsgs = !showAllMsgs;
-    });
-  }
+  void toggleAddingNewMsg() => setState(() { addingNewMsg = !addingNewMsg; });
+
+  void toggleShowAllMsgs() => setState(() { showAllMsgs = !showAllMsgs; });
+
+  Widget taskAddButton() => InkWell(
+    child: taskActionButton(addingNewMsg ? Icons.remove : Icons.add),
+    onTap: toggleAddingNewMsg,
+  );
 
   Widget taskDropdownButton() => InkWell(
     child: taskActionButton(showAllMsgs ? Icons.expand_less : Icons.expand_more),
@@ -33,12 +41,14 @@ class _TaskState extends State<Task> {
 
   @override
   Widget build(BuildContext context) {
+    final bool isMyTask = context.read<Boards>().isMe(widget.task.user.id);
+
     return Column(
       children: [
         if (widget.task.taskMessages != null) Column(
           children: [
             // adding new
-            // list first
+            if (addingNewMsg && isMyTask) EmptyTaskMessage(),
             if (widget.task.taskMessages.isNotEmpty) TaskMessage(taskMsg: widget.task.taskMessages.first),
             if (showAllMsgs && widget.task.taskMessages.length > 1) Column(
               children: widget.task.taskMessages
@@ -46,15 +56,18 @@ class _TaskState extends State<Task> {
                   .map((e) => TaskMessage(taskMsg: e))
                   .toList(),
             ),
-            // others
           ],
         ),
         Row(
           mainAxisAlignment: MainAxisAlignment.end,
           children: [
             taskDropdownButton(),
-            Padding(padding: EdgeInsets.only(right: 10)),
-            taskAddButton(),
+            if (isMyTask) Row(
+              children: [
+                Padding(padding: EdgeInsets.only(right: 10)),
+                taskAddButton(),
+              ],
+            ),
           ],
         )
       ],
@@ -70,9 +83,4 @@ Widget taskActionButton(IconData icon) => Container(
         color: Colors.white
     ),
     child: Icon(icon)
-);
-
-Widget taskAddButton() => InkWell(
-  child: taskActionButton(Icons.add),
-  onTap: () {},
 );

--- a/lib/screens/boards/tasks/task.dart
+++ b/lib/screens/boards/tasks/task.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import '../../../models/boards/user_task.dart';
+import 'task_message.dart';
 
 class Task extends StatefulWidget {
   final UserTask task;
@@ -11,46 +12,29 @@ class Task extends StatefulWidget {
 }
 
 class _TaskState extends State<Task> {
-  bool done;
+  bool showAllMsgs;
 
   @override
   void initState() {
-    done = false; // After server code, init done to task.done
+    showAllMsgs = false; // After server code, init done to task.done
     super.initState();
   }
 
-  void toggleDone(bool val) {
-    // request toggle done to server
+  void toggleShowAllMsgs(bool val) {
     setState(() {
-      done = val;
+      showAllMsgs = val;
     });
   }
   @override
   Widget build(BuildContext context) {
-    return Container(
-      width: double.infinity,
-      height: 40,
-      child: DecoratedBox(
-          decoration: BoxDecoration(
-            borderRadius: BorderRadius.circular(5),
-            color: Colors.white,
-          ),
-          child: Padding(
-            padding: EdgeInsets.only(right: 10),
-            child: Row(
-              children: [
-                Checkbox(
-                    value: done,
-                    onChanged: (val) => toggleDone(val)
-                ),
-                // Text(
-                //   widget.task.task,
-                //   style: TextStyle(fontSize: 14),
-                // ),
-              ],
-            ),
-          )
-      ),
+    return Column(
+      children: [
+        // adding new
+        // list first
+        TaskMessage(taskMsg: widget.task.taskMessages.first),
+        //if (showAllMsgs) widget.task.taskMessages[1:].map()
+        // others
+      ],
     );
   }
 }

--- a/lib/screens/boards/tasks/task.dart
+++ b/lib/screens/boards/tasks/task.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import '../../models/boards/user_task.dart';
+import '../../../models/boards/user_task.dart';
 
 class Task extends StatefulWidget {
   final UserTask task;

--- a/lib/screens/boards/tasks/task.dart
+++ b/lib/screens/boards/tasks/task.dart
@@ -43,12 +43,26 @@ class _TaskState extends State<Task> {
   Widget build(BuildContext context) {
     final bool isMyTask = context.read<Boards>().isMe(widget.task.user.id);
 
+    Future createTaskMsg({Map<String, String> fields, dynamic files}) async {
+      bool res = await context.read<Boards>().createTaskMsg(
+        taskId: widget.task.id,
+        body: {
+          "msg": fields["content"],
+          "status": "ONGOING",
+        },
+      ).then((successful) {
+        if (successful) toggleAddingNewMsg();
+        return successful;
+      });
+
+      return res;
+    }
+
     return Column(
       children: [
         if (widget.task.taskMessages != null) Column(
           children: [
-            // adding new
-            if (addingNewMsg && isMyTask) EmptyTaskMessage(),
+            if (addingNewMsg && isMyTask) EmptyTaskMessage(createTaskMsg: createTaskMsg),
             if (widget.task.taskMessages.isNotEmpty) TaskMessage(taskMsg: widget.task.taskMessages.first),
             if (showAllMsgs && widget.task.taskMessages.length > 1) Column(
               children: widget.task.taskMessages

--- a/lib/screens/boards/tasks/task_message.dart
+++ b/lib/screens/boards/tasks/task_message.dart
@@ -28,9 +28,7 @@ class _TaskMessageState extends State<TaskMessage> {
   @override
   Widget build(BuildContext context) {
     return Container(
-      // constraints: BoxConstraints(
-      //   minHeight: 40,
-      // ),
+      margin: EdgeInsets.only(bottom: 10),
       width: double.infinity,
       child: DecoratedBox(
           decoration: BoxDecoration(
@@ -41,9 +39,15 @@ class _TaskMessageState extends State<TaskMessage> {
             padding: EdgeInsets.only(right: 10),
             child: Row(
               children: [
-                Checkbox(
-                    value: done,
-                    onChanged: (val) => toggleDone(val)
+                ConstrainedBox(
+                  constraints: BoxConstraints(
+                    maxHeight: 40,
+                    minHeight: 40
+                  ),
+                  child: Checkbox(
+                      value: done,
+                      onChanged: (val) => toggleDone(val)
+                  ),
                 ),
                 Expanded(
                   child: Text(

--- a/lib/screens/boards/tasks/task_message.dart
+++ b/lib/screens/boards/tasks/task_message.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/material.dart';
+import '../../../models/boards/task_msg.dart';
+
+class TaskMessage extends StatefulWidget {
+  final TaskMsg taskMsg;
+
+  TaskMessage({@required this.taskMsg});
+
+  @override
+  State<StatefulWidget> createState() => _TaskMessageState();
+}
+
+class _TaskMessageState extends State<TaskMessage> {
+  bool done;
+
+  @override
+  void initState() {
+    done = false; // After server code, init done to task.done
+    super.initState();
+  }
+
+  void toggleDone(bool val) {
+    // request toggle done to server
+    setState(() {
+      done = val;
+    });
+  }
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      // constraints: BoxConstraints(
+      //   minHeight: 40,
+      // ),
+      width: double.infinity,
+      child: DecoratedBox(
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(5),
+            color: Colors.white,
+          ),
+          child: Padding(
+            padding: EdgeInsets.only(right: 10),
+            child: Row(
+              children: [
+                Checkbox(
+                    value: done,
+                    onChanged: (val) => toggleDone(val)
+                ),
+                Expanded(
+                  child: Text(
+                    widget.taskMsg.msg,
+                    style: TextStyle(fontSize: 14),
+                  )
+                ),
+              ],
+            ),
+          )
+      ),
+    );
+  }
+}

--- a/lib/screens/boards/tasks/tasks.dart
+++ b/lib/screens/boards/tasks/tasks.dart
@@ -115,22 +115,7 @@ class TasksState extends State<Tasks> {
               ),
               child: Padding(
                 padding: EdgeInsets.all(10),
-                child: Column(
-                  children: [
-                    if (selectedUserTask.taskMessages != null) Task(task: selectedUserTask),
-                    Padding(
-                      padding: EdgeInsets.only(top: 10),
-                      child: Row(
-                        mainAxisAlignment: MainAxisAlignment.end,
-                        children: [
-                          progressDropdownButton(),
-                          Padding(padding: EdgeInsets.only(right: 10)),
-                          addProgressButton(),
-                        ],
-                      ),
-                    )
-                  ],
-                ),
+                child: Task(task: selectedUserTask),
               )
             )
           )
@@ -152,25 +137,5 @@ Widget positionChip({@required String position}) => DecoratedBox(
       style: TextStyle(fontSize: 10),
     ), // temp
   ),
-);
-
-Widget progressButton(IconData icon) => Container(
-  width: 30,
-  height: 30,
-  decoration: BoxDecoration(
-      borderRadius: BorderRadius.circular(30),
-      color: Colors.white
-  ),
-  child: Icon(icon)
-);
-
-Widget progressDropdownButton() => InkWell(
-  child: progressButton(Icons.expand_more),
-  onTap: () {},
-);
-
-Widget addProgressButton() => InkWell(
-  child: progressButton(Icons.add),
-  onTap: () {},
 );
 

--- a/lib/screens/boards/tasks/tasks.dart
+++ b/lib/screens/boards/tasks/tasks.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:guam_front/commons/profile_thumbnail.dart';
-import '../../models/boards/user_task.dart';
-import 'iconTitle.dart';
+import '../../../models/boards/user_task.dart';
+import '../iconTitle.dart';
 import 'task.dart';
 
 class Tasks extends StatefulWidget {
@@ -117,7 +117,7 @@ class TasksState extends State<Tasks> {
                 padding: EdgeInsets.all(10),
                 child: Column(
                   children: [
-                    //if (selectedUserTask.task != null) Task(task: selectedUserTask),
+                    if (selectedUserTask.taskMessages != null) Task(task: selectedUserTask),
                     Padding(
                       padding: EdgeInsets.only(top: 10),
                       child: Row(

--- a/lib/screens/boards/threads/thread.dart
+++ b/lib/screens/boards/threads/thread.dart
@@ -4,14 +4,14 @@ import 'package:intl/intl.dart';
 import 'package:modal_bottom_sheet/modal_bottom_sheet.dart';
 import 'package:provider/provider.dart';
 import 'dart:io' show Platform;
-import '../../providers/boards/boards.dart';
-import '../../providers/user_auth/authenticate.dart';
-import '../../commons/profile_thumbnail.dart';
-import '../../models/boards/thread.dart' as ThreadModel;
-import 'thread_page/thread_page.dart';
-import 'thread_page/thread_comment_images.dart';
-import 'bottom_modal/bottom_modal_content.dart';
-import 'accept_decline_button.dart';
+import '../../../providers/boards/boards.dart';
+import '../../../providers/user_auth/authenticate.dart';
+import '../../../commons/profile_thumbnail.dart';
+import '../../../models/boards/thread.dart' as ThreadModel;
+import '../thread_page/thread_page.dart';
+import '../thread_page/thread_comment_images.dart';
+import '../bottom_modal/bottom_modal_content.dart';
+import '../accept_decline_button.dart';
 
 class Thread extends StatelessWidget {
   final ThreadModel.Thread thread;

--- a/lib/screens/boards/threads/threads.dart
+++ b/lib/screens/boards/threads/threads.dart
@@ -1,10 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import '../../commons/common_text_field.dart';
-import '../../providers/boards/boards.dart';
-import '../../models/boards/thread.dart' as ThreadModel;
+import '../../../commons/common_text_field.dart';
+import '../../../providers/boards/boards.dart';
+import '../../../models/boards/thread.dart' as ThreadModel;
 import 'thread.dart';
-import 'iconTitle.dart';
+import '../iconTitle.dart';
 
 class Threads extends StatefulWidget {
   final List<ThreadModel.Thread> threads;


### PR DESCRIPTION
TASK
- GET project/id 에 담긴 TASK의 필드는 id, user의 id, userState 만으로 축소
- TASK create, update status 가능

----
TASK align을 '나 먼저' 로 하면 edit status 등 시 갑작스런 task 전환이 없을 텐데, 이 부분은 아직 미개발이라 후속 PR에 넣겠습니다. 
TASK edit, delete 은 쉽게 개발 가능 (곧 하겠습니다)