### PR TITLE
Toast failure event handling

### DIFF
--- a/lib/commons/images_carousel_page.dart
+++ b/lib/commons/images_carousel_page.dart
@@ -82,7 +82,6 @@ class ImagesCarouselPageState extends State<ImagesCarouselPage> {
                     deleteFunc: () async {
                       await widget.deleteFunc(imageId: thumbnailsState[currPage].id)
                         .then((successful) {
-                          print(successful);
                           if (successful) {
                             Navigator.of(context).pop(); // pop Modal Bottom Content
                             afterDelete();

--- a/lib/helpers/http_request.dart
+++ b/lib/helpers/http_request.dart
@@ -94,9 +94,7 @@ class HttpRequest with Toast {
           headers: {'Content-Type': "application/json", HttpHeaders.authorizationHeader: authToken},
       );
 
-      if (response.statusCode == 200) {
-        return response;
-      }
+      return response;
     } catch (e) {
       print("Error on DELETE request: $e");
       showToast(success: false);

--- a/lib/helpers/http_request.dart
+++ b/lib/helpers/http_request.dart
@@ -3,8 +3,9 @@ import 'dart:io' show File, HttpHeaders;
 import 'package:http/http.dart' as http;
 import 'package:http_parser/http_parser.dart';
 import 'package:path/path.dart' as p;
+import '../mixins/toast.dart';
 
-class HttpRequest {
+class HttpRequest with Toast {
   final String baseAuthority = "15.164.72.46:8080";
   final String s3BaseAuthority = "https://guam.s3.ap-northeast-2.amazonaws.com/";
 
@@ -19,6 +20,7 @@ class HttpRequest {
       return response;
     } catch (e) {
       print("Error on GET request: $e");
+      showToast(success: false);
     }
   }
 
@@ -35,6 +37,7 @@ class HttpRequest {
       return response;
     } catch (e) {
       print("Error on POST request: $e");
+      showToast(success: false);
     }
   }
 
@@ -62,6 +65,7 @@ class HttpRequest {
       return response;
     } catch (e) {
       print("Error on POST Multipart request: $e");
+      showToast(success: false);
     }
   }
 
@@ -78,6 +82,7 @@ class HttpRequest {
       return response;
     } catch (e) {
       print("Error on PUT request: $e");
+      showToast(success: false);
     }
   }
 
@@ -94,6 +99,7 @@ class HttpRequest {
       }
     } catch (e) {
       print("Error on DELETE request: $e");
+      showToast(success: false);
     }
   }
 }

--- a/lib/providers/boards/boards.dart
+++ b/lib/providers/boards/boards.dart
@@ -489,7 +489,7 @@ class Boards extends ChangeNotifier with Toast {
     return res;
   }
 
-  Future postComment({int threadId, Map<String, dynamic> fields, dynamic files}) async {
+  Future<bool> postComment({int threadId, Map<String, dynamic> fields, dynamic files}) async {
     bool res = false;
 
     try {
@@ -498,8 +498,7 @@ class Boards extends ChangeNotifier with Toast {
       await HttpRequest()
         .postMultipart(
           authToken: authToken,
-        path: "/comment/create/1111",
-        // path: "/comment/create/$threadId",
+          path: "/comment/create/$threadId",
           fields: fields,
           files: files,
       ).then((response) {
@@ -507,9 +506,10 @@ class Boards extends ChangeNotifier with Toast {
           showToast(success: true, msg: "답글이 등록되었습니다.");
           res = true;
         } else {
-          final jsonUtf8 = decodeKo(response);
-          final String err = json.decode(jsonUtf8)["message"];
-          showToast(success: false, msg: err);
+          response.stream.bytesToString().then((val) {
+            final String err = json.decode(val)["message"];
+            showToast(success: false, msg: err);
+          });
         }
       });
     } catch (e) {
@@ -521,7 +521,7 @@ class Boards extends ChangeNotifier with Toast {
     return res;
   }
 
-  Future editCommentContent({int commentId, Map<String, dynamic> fields}) async {
+  Future<bool> editCommentContent({int commentId, Map<String, dynamic> fields}) async {
     bool res = false;
 
     try {
@@ -549,7 +549,7 @@ class Boards extends ChangeNotifier with Toast {
     return res;
   }
 
-  Future deleteComment(int commentId) async {
+  Future<bool> deleteComment(int commentId) async {
     bool res = false;
 
     try {
@@ -578,16 +578,16 @@ class Boards extends ChangeNotifier with Toast {
     return res;
   }
 
-  Future deleteCommentImage({int commentId, int imageId}) async {
+  Future<bool> deleteCommentImage({int commentId, int imageId}) async {
     bool res = false;
 
     try {
       String authToken = await _authProvider.getFirebaseIdToken();
 
       await HttpRequest()
-      .delete(
-        path: "/comment/$commentId/image/$imageId",
-        authToken: authToken,
+        .delete(
+          path: "/comment/$commentId/image/$imageId",
+          authToken: authToken,
       ).then((response) {
         if (response.statusCode == 200) {
           showToast(success: true, msg: "이미지가 삭제되었습니다.");

--- a/lib/providers/boards/boards.dart
+++ b/lib/providers/boards/boards.dart
@@ -605,7 +605,7 @@ class Boards extends ChangeNotifier with Toast {
     return res;
   }
 
-  Future acceptDecline({int userId, bool accept}) async {
+  Future<void> acceptDecline({int userId, bool accept}) async {
     bool res = false;
 
     try {
@@ -613,7 +613,7 @@ class Boards extends ChangeNotifier with Toast {
 
       await HttpRequest()
         .post(
-          path: "/project/${currentBoard.id}/$userId",
+          path: "/project/${currentBoard.id}/115",
           authToken: authToken,
           queryParams: { "accept": "$accept" }
       ).then((response) {
@@ -635,7 +635,7 @@ class Boards extends ChangeNotifier with Toast {
     }
   }
 
-  Future quitBoard() async {
+  Future<bool> quitBoard() async {
     bool res = false;
 
     try {
@@ -665,7 +665,7 @@ class Boards extends ChangeNotifier with Toast {
     return res;
   }
 
-  Future deleteBoard() async {
+  Future<bool> deleteBoard() async {
     bool res = false;
 
     try {

--- a/lib/providers/boards/boards.dart
+++ b/lib/providers/boards/boards.dart
@@ -44,19 +44,25 @@ class Boards extends ChangeNotifier with Toast {
     fetchBoardIds();
   }
 
-  Future fetchBoardIds() async {
-    try {
-      loading = true;
+  Future<void> fetchBoardIds() async {
+    loading = true;
 
+    try {
       if (_authProvider.userSignedIn()) {
         await HttpRequest()
           .get(
             path: "user/project/ids",
             authToken: await _authProvider.getFirebaseIdToken()
           ).then((response) {
-            final jsonUtf8 = decodeKo(response);
-            final List<dynamic> jsonList = json.decode(jsonUtf8)["data"];
-            _boards = jsonList.map((e) => Project.fromJson({ "id": e })).toList();
+            if (response.statusCode == 200) {
+              final jsonUtf8 = decodeKo(response);
+              final List<dynamic> jsonList = json.decode(jsonUtf8)["data"];
+              _boards = jsonList.map((e) => Project.fromJson({ "id": e })).toList();
+            } else {
+              final jsonUtf8 = decodeKo(response);
+              final String err = json.decode(jsonUtf8)["message"];
+              showToast(success: false, msg: err);
+            }
         });
       }
     } catch (e) {
@@ -66,9 +72,11 @@ class Boards extends ChangeNotifier with Toast {
     }
   }
 
-  Future fetchBoard(int projectId) async {
+  Future<void> fetchBoard(int projectId) async {
+    print("Start fetching board");  ///
+    loading = true;
+
     try {
-      loading = true;
       String authToken = await _authProvider.getFirebaseIdToken();
 
       await HttpRequest()
@@ -76,27 +84,34 @@ class Boards extends ChangeNotifier with Toast {
           path: "/project/$projectId",
           authToken: authToken
         ).then((response) {
-          final jsonUtf8 = decodeKo(response);
-          final Map<String, dynamic> jsonData = json.decode(jsonUtf8)["data"];
-          boards[renderBoardIdx] = Project.fromJson(jsonData);
+          if (response.statusCode == 200) {
+            final jsonUtf8 = decodeKo(response);
+            final Map<String, dynamic> jsonData = json.decode(jsonUtf8)["data"];
+            boards[renderBoardIdx] = Project.fromJson(jsonData);
+            print("Finished fetching board info");  ///
+          } else {
+            final jsonUtf8 = decodeKo(response);
+            final String err = json.decode(jsonUtf8)["message"];
+            showToast(success: false, msg: err);
+          }
       });
 
+      // 순서 중요! Thread.dart 에서 task
       await setTasks();
       await fetchThreads();
-
-      loading = false;
     } catch (e) {
       print(e);
     } finally {
+      loading = false;
       notifyListeners();
     }
   }
 
-  Future editProject({int projectId, Map<String, dynamic> fields, dynamic files}) async {
+  Future<bool> editProject({int projectId, Map<String, dynamic> fields, dynamic files}) async {
+    bool res = false;
+
     try {
-      loading = true;
       String authToken = await _authProvider.getFirebaseIdToken();
-      bool res = false;
 
       if (authToken.isNotEmpty) {
         await HttpRequest()
@@ -110,21 +125,22 @@ class Boards extends ChangeNotifier with Toast {
               res = true;
               showToast(success: true, msg: "프로젝트를 수정했습니다.");
             } else {
-              final jsonUtf8 = decodeKo(response);
-              final String err = json.decode(jsonUtf8)["message"];
-              showToast(success: false, msg: err);
+              response.stream.bytesToString().then((val) {
+                final String err = json.decode(val)["message"];
+                showToast(success: false, msg: err);
+              });
             }
           });
       }
-      return res;
     } catch (e) {
       print(e);
-    } finally {
-      loading = false;
     }
+
+    return res;
   }
 
-  Future setTasks() async {
+  Future<void> setTasks() async {
+    print("Start set tasks"); ///
     List<UserTask> newTasks = [];
 
     for (UserTask briefTask in currentBoard.tasks) {
@@ -136,6 +152,7 @@ class Boards extends ChangeNotifier with Toast {
     }
 
     currentBoard.tasks = newTasks;
+    print("Finished set tasks");  ///
   }
 
   Future<UserTask> fetchTask(int taskId) async {
@@ -165,7 +182,7 @@ class Boards extends ChangeNotifier with Toast {
     return userTask;
   }
 
-  Future createTaskMsg({int taskId, Map<String, String> body}) async {
+  Future<bool> createTaskMsg({int taskId, Map<String, String> body}) async {
     bool res = false;
 
     try {
@@ -196,7 +213,7 @@ class Boards extends ChangeNotifier with Toast {
     return res;
   }
 
-  Future updateTaskMsg({int taskMsgId, Map<String, String> body}) async {
+  Future<void> updateTaskMsg({int taskMsgId, Map<String, String> body}) async {
     bool res = false;
 
     try {
@@ -258,8 +275,10 @@ class Boards extends ChangeNotifier with Toast {
   }
 
   Future fetchThreads({dynamic queryParams}) async {
+    print("Start fetch threads"); ///
+    loading = true;
+
     try {
-      loading = true;
       String authToken = await _authProvider.getFirebaseIdToken();
 
       await HttpRequest()
@@ -276,6 +295,7 @@ class Boards extends ChangeNotifier with Toast {
           final List<dynamic> jsonData = json.decode(jsonUtf8)["data"];
           final List<Thread> threads = [...jsonData.map((e) => Thread.fromJson(e))];
           currentBoard.threads = threads;
+          print("Finished fetch threads"); ///
         } else {
           final jsonUtf8 = decodeKo(response);
           final String err = json.decode(jsonUtf8)["message"];
@@ -320,7 +340,7 @@ class Boards extends ChangeNotifier with Toast {
     return comments;
   }
 
-  Future postThread({Map<String, dynamic> fields, dynamic files}) async {
+  Future<bool> postThread({Map<String, dynamic> fields, dynamic files}) async {
     bool res = false;
 
     try {
@@ -337,9 +357,11 @@ class Boards extends ChangeNotifier with Toast {
           showToast(success: true, msg: "스레드가 등록되었습니다.");
           res = true;
         } else {
-          final jsonUtf8 = decodeKo(response);
-          final String err = json.decode(jsonUtf8)["message"];
-          showToast(success: false, msg: err);        }
+          response.stream.bytesToString().then((val) {
+            final String err = json.decode(val)["message"];
+            showToast(success: false, msg: err);
+          });
+        }
       });
     } catch (e) {
       print(e);
@@ -350,7 +372,7 @@ class Boards extends ChangeNotifier with Toast {
     return res;
   }
 
-  Future editThreadContent({int threadId, Map<String, dynamic> fields}) async {
+  Future<bool> editThreadContent({int threadId, Map<String, dynamic> fields}) async {
     bool res = false;
 
     try {
@@ -380,7 +402,7 @@ class Boards extends ChangeNotifier with Toast {
     return res;
   }
 
-  Future setNotice(int threadId) async {
+  Future<bool> setNotice(int threadId) async {
     bool res = false;
 
     try {
@@ -438,16 +460,16 @@ class Boards extends ChangeNotifier with Toast {
     return res;
   }
 
-  Future deleteThreadImage({int threadId, int imageId}) async {
+  Future<bool> deleteThreadImage({int threadId, int imageId}) async {
     bool res = false;
 
     try {
       String authToken = await _authProvider.getFirebaseIdToken();
 
       await HttpRequest()
-      .delete(
-        path: "/thread/$threadId/image/$imageId",
-        authToken: authToken,
+        .delete(
+         path: "/thread/$threadId/image/$imageId",
+         authToken: authToken,
       ).then((response) {
         if (response.statusCode == 200) {
           showToast(success: true, msg: "이미지가 삭제되었습니다.");
@@ -476,7 +498,8 @@ class Boards extends ChangeNotifier with Toast {
       await HttpRequest()
         .postMultipart(
           authToken: authToken,
-          path: "/comment/create/$threadId",
+        path: "/comment/create/1111",
+        // path: "/comment/create/$threadId",
           fields: fields,
           files: files,
       ).then((response) {

--- a/lib/providers/projects/projects.dart
+++ b/lib/providers/projects/projects.dart
@@ -33,30 +33,22 @@ class Projects extends ChangeNotifier with Toast {
     try {
       loading = true;
 
-      await HttpRequest().get(path: "/project/list").then((response) async {
-        if (response.statusCode == 200) {
-          final jsonUtf8 = decodeKo(response);
-          final List<dynamic> jsonList = json.decode(jsonUtf8)["data"];
-          _projects = jsonList.map((e) => Project.fromJson(e)).toList();
-        } else {
-          final jsonUtf8 = decodeKo(response);
-          final String err = json.decode(jsonUtf8)["message"];
-          showToast(success: false, msg: err);
-        }
-      });
-
-      await HttpRequest().get(path: "/project/tab").then((response) {
-        if (response.statusCode == 200) {
-          final jsonUtf8 = decodeKo(response);
-          final List<dynamic> jsonList = json.decode(jsonUtf8)["data"];
-          _almostFullProjects =
-              jsonList.map((e) => Project.fromJson(e)).toList();
-        } else {
-          final jsonUtf8 = decodeKo(response);
-          final String err = json.decode(jsonUtf8)["message"];
-          showToast(success: false, msg: err);
-        }
-      });
+      await Future.wait([
+        HttpRequest().get(path: "/project/list").then((response) async {
+          if (response.statusCode == 200) {
+            final jsonUtf8 = decodeKo(response);
+            final List<dynamic> jsonList = json.decode(jsonUtf8)["data"];
+            _projects = jsonList.map((e) => Project.fromJson(e)).toList();
+          }
+        }),
+        HttpRequest().get(path: "/project/tab").then((response) {
+          if (response.statusCode == 200) {
+            final jsonUtf8 = decodeKo(response);
+            final List<dynamic> jsonList = json.decode(jsonUtf8)["data"];
+            _almostFullProjects = jsonList.map((e) => Project.fromJson(e)).toList();
+          }
+        })
+      ]);
 
       loading = false;
     } catch (e) {
@@ -64,6 +56,16 @@ class Projects extends ChangeNotifier with Toast {
     } finally {
       notifyListeners();
     }
+  }
+
+  void getAllProjects() async {
+    HttpRequest().get(path: "/project/list").then((response) {
+      if (response.statusCode == 200) {
+        final jsonUtf8 = decodeKo(response);
+        final List<dynamic> jsonList = json.decode(jsonUtf8)["data"];
+        _projects = jsonList.map((e) => Project.fromJson(e)).toList();
+      }
+    });
   }
 
   Future getProject(int projectId) async {

--- a/lib/providers/projects/projects.dart
+++ b/lib/providers/projects/projects.dart
@@ -55,6 +55,10 @@ class Projects extends ChangeNotifier with Toast {
         final List<dynamic> jsonList = json.decode(jsonUtf8)["data"];
         _projects = jsonList.map((e) => Project.fromJson(e)).toList();
         print("get all projects done");   ///
+      } else {
+        final jsonUtf8 = decodeKo(response);
+        final String err = json.decode(jsonUtf8)["message"];
+        showToast(success: false, msg: err);
       }
     });
   }
@@ -68,6 +72,10 @@ class Projects extends ChangeNotifier with Toast {
         final List<dynamic> jsonList = json.decode(jsonUtf8)["data"];
         _almostFullProjects = jsonList.map((e) => Project.fromJson(e)).toList();
         print("get almost full projects done"); ///
+      } else {
+        final jsonUtf8 = decodeKo(response);
+        final String err = json.decode(jsonUtf8)["message"];
+        showToast(success: false, msg: err);
       }
     });
   }
@@ -82,6 +90,10 @@ class Projects extends ChangeNotifier with Toast {
           if (response.statusCode == 200) {
             final jsonUtf8 = decodeKo(response);
             project = Project.fromJson(json.decode(jsonUtf8)["data"]);
+          } else {
+            final jsonUtf8 = decodeKo(response);
+            final String err = json.decode(jsonUtf8)["message"];
+            showToast(success: false, msg: err);
           }
       });
     } catch (e) {
@@ -104,6 +116,10 @@ class Projects extends ChangeNotifier with Toast {
             final List<dynamic> jsonList = json.decode(jsonUtf8)["data"];
             _filteredProjects = jsonList.map((e) => Project.fromJson(e)).toList();
             print("set filted projects done");  ///
+          } else {
+            final jsonUtf8 = decodeKo(response);
+            final String err = json.decode(jsonUtf8)["message"];
+            showToast(success: false, msg: err);
           }
       });
     } catch (e) {

--- a/lib/providers/projects/projects.dart
+++ b/lib/providers/projects/projects.dart
@@ -33,7 +33,7 @@ class Projects extends ChangeNotifier with Toast {
     try {
       loading = true;
 
-      await HttpRequest().get(path: "/project/list").then((response) {
+      await HttpRequest().get(path: "/project/list").then((response) async {
         if (response.statusCode == 200) {
           final jsonUtf8 = decodeKo(response);
           final List<dynamic> jsonList = json.decode(jsonUtf8)["data"];
@@ -116,7 +116,7 @@ class Projects extends ChangeNotifier with Toast {
   }
 
   Future createProject({Map<String, dynamic> fields, dynamic files}) async {
-    bool res = false;
+    bool successful = false;
 
     try {
       loading = true;
@@ -129,24 +129,25 @@ class Projects extends ChangeNotifier with Toast {
             authToken: authToken,
             fields: fields,
             files: files,
-          ).then((response) async {
+          ).then((response) {
             if (response.statusCode == 200) {
               showToast(success: true, msg: "프로젝트가 생성되었습니다.");
-              res = true;
+              successful = true;
             } else {
-              final jsonUtf8 = decodeKo(response);
-              final String err = json.decode(jsonUtf8)["message"];
-              showToast(success: false, msg: err);
+              response.stream.bytesToString().then((val) {
+                final String err = json.decode(val)["message"];
+                showToast(success: false, msg: err);
+              });
             }
           });
       }
+
+      return successful;
     } catch (e) {
       print(e);
     } finally {
       loading = false;
     }
-
-    return res;
   }
 
   Future applyProject(int projectId, dynamic queryParams) async {

--- a/lib/providers/stacks/stacks.dart
+++ b/lib/providers/stacks/stacks.dart
@@ -27,6 +27,10 @@ class Stacks extends ChangeNotifier with Toast {
           final List<dynamic> jsonList = json.decode(jsonUtf8);
           _stacks = jsonList.map((e) => StackModel.Stack.fromJson(e)).toList();
           print("fetch stacks done"); ///
+        } else {
+          final jsonUtf8 = decodeKo(response);
+          final String err = json.decode(jsonUtf8)["message"];
+          showToast(success: false, msg: err);
         }
       });
     } catch (e) {

--- a/lib/providers/stacks/stacks.dart
+++ b/lib/providers/stacks/stacks.dart
@@ -6,7 +6,9 @@ import '../../models/stack.dart' as StackModel;
 import '../../mixins/toast.dart';
 
 class Stacks extends ChangeNotifier with Toast {
-  List<StackModel.Stack> _stacks;
+  // _stacks init to empty list for avoiding errors from calling get stacks,
+  // when fetchStacks() has not yet ended.
+  List<StackModel.Stack> _stacks = [];
 
   Stacks() {
     fetchStacks();
@@ -14,7 +16,8 @@ class Stacks extends ChangeNotifier with Toast {
 
   get stacks => _stacks;
 
-  Future fetchStacks() async {
+  Future<void> fetchStacks() async {
+    print("fetch stacks start"); ///
     try {
       await HttpRequest().get(
         path: "/stacks"
@@ -23,10 +26,7 @@ class Stacks extends ChangeNotifier with Toast {
           final jsonUtf8 = decodeKo(response);
           final List<dynamic> jsonList = json.decode(jsonUtf8);
           _stacks = jsonList.map((e) => StackModel.Stack.fromJson(e)).toList();
-        } else {
-          final jsonUtf8 = decodeKo(response);
-          final String err = json.decode(jsonUtf8)["message"];
-          showToast(success: false, msg: err);
+          print("fetch stacks done"); ///
         }
       });
     } catch (e) {

--- a/lib/providers/user_auth/authenticate.dart
+++ b/lib/providers/user_auth/authenticate.dart
@@ -111,9 +111,10 @@ class Authenticate extends ChangeNotifier with Toast {
               showToast(success: true, msg: "프로필을 생성하였습니다.");
               res = true;
             } else {
-              final jsonUtf8 = decodeKo(response);
-              final String err = json.decode(jsonUtf8)["message"];
-              showToast(success: false, msg: err);
+              response.stream.bytesToString().then((val) {
+                final String err = json.decode(val)["message"];
+                showToast(success: false, msg: err);
+              });
             }
           });
       }


### PR DESCRIPTION
!중요
postMultipart request의 경우에만 에러 로깅을 이런 식으로 해야 합니다. 이 경우에만 error가 streamedResponse 형태로 와서 그런데 이유는 찾아봐야 할 듯 합니다. 

              response.stream.bytesToString().then((val) {
                final String err = json.decode(val)["message"];
                showToast(success: false, msg: err);
              });

나머지는 평소처럼 하셔도 됩니다. 

            final jsonUtf8 = decodeKo(response);
            final String err = json.decode(jsonUtf8)["message"];
            showToast(success: false, msg: err);

전체 API에 exception을 토스트로 걸어 달라고 하셔서 걸었습니다. 클라에서 request 에러가 나거나, 에러가 500 같은 거면 http_request의 toast에 걸릴 것인데, 이때는 toast msg가 디폴트로 들어가며 메서드 내부에서 statusCode로 걸리면 서버에서 던져준 error msg가 toast msg로 들어갑니다! 