### PR TITLE
Fix/project title length and logout edit

### DIFF
--- a/lib/screens/my_page/my_page_app.dart
+++ b/lib/screens/my_page/my_page_app.dart
@@ -17,7 +17,7 @@ class MyPage extends StatelessWidget {
     return Scaffold(
       appBar: CustomAppBar(
         title: "프로필",
-        trailing: authProvider.profileExists()
+        trailing: authProvider.profileExists() && authProvider.userSignedIn()
             ? TextButton(
                 child: Text(
                   'Edit',

--- a/lib/screens/projects/creation/page_one/project_create_title.dart
+++ b/lib/screens/projects/creation/page_one/project_create_title.dart
@@ -39,9 +39,9 @@ class _ProjectCreateTitleState extends State<ProjectCreateTitle> {
         ),
         Container(
           padding: EdgeInsets.only(left: 20, right: 20),
-          height: 70,
+          height: 75,
           child: TextFormField(
-          maxLength: 20,
+          maxLength: 30,
             onChanged: (text) {
               setState(() {widget.input["title"] = text;});
               widget.checkButtonEnable();


### PR DESCRIPTION
> resolves #77 

1. 로그아웃 후 Edit 버튼 안 보이게 수정

2. 프로젝트 생성/수정 시 제목의 길이를 기존의 20자에서 30자로 수정
> form에서 텍스트 길이가 길어질 때 글자 아랫 부분이 잘리는 현상 수정